### PR TITLE
Fix for Windows ESBuild issues

### DIFF
--- a/src/lustre_dev_tools_ffi.erl
+++ b/src/lustre_dev_tools_ffi.erl
@@ -23,8 +23,8 @@ get_cpu() ->
             list_to_binary(Arch);
         {win32, _} ->
             case erlang:system_info(wordsize) of
-                4 -> {ok, <<"ia32">>};
-                8 -> {ok, <<"x64">>}
+                4 -> <<"ia32">>;
+                8 -> <<"x64">>
             end
     end.
 
@@ -51,7 +51,7 @@ get_tailwind(Url) ->
 unzip_esbuild(Zip) ->
     Result =
         erl_tar:extract({binary, Zip}, [
-            memory, compressed, {files, ["package/bin/esbuild"]}
+            memory, compressed, {files, ["package/bin/esbuild", "package/esbuild.exe"]}
         ]),
 
     case Result of

--- a/src/lustre_dev_tools_ffi.erl
+++ b/src/lustre_dev_tools_ffi.erl
@@ -49,9 +49,15 @@ get_tailwind(Url) ->
     end.
 
 unzip_esbuild(Zip) ->
+    Filepath =
+        case os:type() of 
+            {win32, _} -> "package/esbuild.exe";
+            _ -> "package/bin/esbuild"
+        end,
+
     Result =
         erl_tar:extract({binary, Zip}, [
-            memory, compressed, {files, ["package/bin/esbuild", "package/esbuild.exe"]}
+            memory, compressed, {files, [Filepath]}
         ]),
 
     case Result of


### PR DESCRIPTION
Fixes #14!

I've tested this in an example project on my machine and everything works as expected. `localhost:1234` opens up with a sample Lustre app.

I'm not sure how safe it is to list two file paths for the ESBuild binary. the location/name is different between platforms, so it feels like the likelihood of a single archive containing files at both paths is extremely slim. Maybe having a function that returns the expected binary path would make more sense here?

Is there a preferred way to solve this problem?