### PR TITLE
add flag to support debug inclusion within a running project

### DIFF
--- a/src/lustre_dev_tools/cli/start.gleam
+++ b/src/lustre_dev_tools/cli/start.gleam
@@ -35,6 +35,7 @@ Watchexec is a popular tool you can use to restart the server when files change.
       flag.get_bool(flags, "use-example-styles")
     let assert Ok(no_spa) = flag.get_bool(flags, "no-spa")
     let custom_html = flag.get_string(flags, "html")
+    let assert Ok(debug) = flag.get_bool(flags, "debug")
 
     let script = {
       use <- cli.log("Building your project")
@@ -95,6 +96,7 @@ Watchexec is a popular tool you can use to restart the server when files change.
           filepath.join(tempdir, "entry.mjs"),
           filepath.join(tempdir, "index.mjs"),
           False,
+          debug,
         )
         |> cli.map_error(BundleError),
       )
@@ -156,6 +158,16 @@ Watchexec is a popular tool you can use to restart the server when files change.
       |> string.trim_right
 
     flag.string()
+    |> flag.description(description)
+  })
+  |> glint.flag("debug", {
+    let description =
+      "The dev server will include debug and performance intstrumentation in the project while being served."
+      |> string.trim_right
+    let default = False
+
+    flag.bool()
+    |> flag.default(default)
     |> flag.description(description)
   })
 }

--- a/src/lustre_dev_tools/esbuild.gleam
+++ b/src/lustre_dev_tools/esbuild.gleam
@@ -1,6 +1,7 @@
 // IMPORTS ---------------------------------------------------------------------
 
 import filepath
+import gleam/bool
 import gleam/dynamic.{type Dynamic}
 import gleam/io
 import gleam/list
@@ -46,6 +47,7 @@ pub fn bundle(
   input_file: String,
   output_file: String,
   minify: Bool,
+  debug: Bool,
 ) -> Cli(any, Nil, Error) {
   use _ <- cli.do(download(get_os(), get_cpu()))
   use _ <- cli.try(project.build(), fn(_) { BuildError })
@@ -58,6 +60,7 @@ pub fn bundle(
     "--bundle",
     "--external:node:*",
     "--format=esm",
+    "--define:DEBUG=" <> string.lowercase(bool.to_string(debug)),
     "--outfile=" <> output_file,
   ]
   let options = case minify {


### PR DESCRIPTION
### Summary 

Add flags in a couple places to define `DEBUG` during the `esbuild` bundle process. This opens up the ability to conditionally include instrumentation in the `*.js` output.

This opens up the ability to add things like this:
```
DEBUG && performance.mark(..)
```
Following this doc: https://esbuild.github.io/api/#define

This is part of pre-work for a set of features to test performance and functionality