### PR TITLE
:bug: Fix subcommand `build` using `add`'s description.

### DIFF
--- a/src/lustre/dev.gleam
+++ b/src/lustre/dev.gleam
@@ -34,7 +34,7 @@ pub fn main() {
     at: ["build"],
     do: glint.command(fn(_) { Nil })
       |> glint.unnamed_args(glint.EqArgs(0))
-      |> glint.description(add.description),
+      |> glint.description(build.description),
   )
   |> glint.add(at: ["build", "app"], do: build.app())
   |> glint.add(at: ["build", "component"], do: build.component())


### PR DESCRIPTION
### Summary
This fixes the subcommand `build` displaying the wrong description when running - for example - `gleam run -m lustre/dev -- --help` or `gleam run -m lustre/dev build -- --help`.

### Examples
As of v1.1.1, here are the CLI outputs:
```console
$ gleam run -m lustre/dev -- --help
[...]

SUBCOMMANDS:
	add		
Commands for adding external binaries to your project. These are run and managed
by Lustre, and while not typically intended to be run manually, they can be found
inside `build/.lustre/bin`.

	build		
Commands for adding external binaries to your project. These are run and managed
by Lustre, and while not typically intended to be run manually, they can be found
inside `build/.lustre/bin`.
[...]
```

```console
$ gleam run -m lustre/dev build -- --help
   Compiled in 0.06s
    Running lustre/dev.main
build

Commands for adding external binaries to your project. These are run and managed
by Lustre, and while not typically intended to be run manually, they can be found
inside `build/.lustre/bin`.
[...]
```