### PR TITLE
:bug: Use correct architecture names on FreeBSD for esbuild

### DIFF
--- a/src/lustre_dev_tools/error.gleam
+++ b/src/lustre_dev_tools/error.gleam
@@ -441,7 +441,7 @@ ran into this issue.
 }
 
 fn unknown_platform(binary: String, os: String, cpu: String) -> String {
-  let path = "./build/.lustre/binary/" <> binary
+  let path = "./build/.lustre/bin/" <> binary
   let message =
     "
 I ran into a problem trying to download the {binary} binary. I couldn't find a

--- a/src/lustre_dev_tools/esbuild.gleam
+++ b/src/lustre_dev_tools/esbuild.gleam
@@ -92,8 +92,8 @@ fn get_download_url(os, cpu) {
     "darwin", "arm64" -> Ok("darwin-arm64/-/darwin-arm64-0.19.10.tgz")
     "darwin", "x86_64" -> Ok("darwin-x64/-/darwin-x64-0.19.10.tgz")
 
-    "freebsd", "arm64" -> Ok("freebsd-arm64/-/freebsd-arm64-0.19.10.tgz")
-    "freebsd", "x64" -> Ok("freebsd-x64/-/freebsd-x64-0.19.10.tgz")
+    "freebsd", "aarch64" -> Ok("freebsd-arm64/-/freebsd-arm64-0.19.10.tgz")
+    "freebsd", "amd64" -> Ok("freebsd-x64/-/freebsd-x64-0.19.10.tgz")
 
     "linux", "aarch64" -> Ok("linux-arm64/-/linux-arm64-0.19.10.tgz")
     "linux", "arm" -> Ok("linux-arm/-/linux-arm-0.19.10.tgz")


### PR DESCRIPTION
On FreeBSD, when running `gleam run -m lustre/dev add esbuild`, it fails due to
incorrect architecture names. On FreeBSD, architectures are named differently
to Linux. The URLs for downloading esbuild are correct, though.

```
# arm64
I ran into a problem trying to download the esbuild binary. I couldn't find a
compatible binary for the following platform:

    OS: freebsd
    CPU: aarch64

# x86_64
I ran into a problem trying to download the esbuild binary. I couldn't find a
compatible binary for the following platform:

    OS: freebsd
    CPU: amd64
```

test on both architectures, it's fixed. thanks!