### PR TITLE
:bug: Add missing double quotes in the template index.html

### DIFF
--- a/priv/template/index.html
+++ b/priv/template/index.html
@@ -7,7 +7,7 @@
     <title>🚧 {app_name}</title>
 
     <!-- Uncomment this if you add the TailwindCSS integration -->
-    <!-- <link rel="stylesheet" href="/priv/static/{app_name}.css> -->
+    <!-- <link rel="stylesheet" href="/priv/static/{app_name}.css"> -->
     <script type="module" src="/priv/static/{app_name}.mjs"></script>
   </head>
 


### PR DESCRIPTION
Hi,
I noticed there was a missing double quote in the template of the `index.html`. If you simply uncomment the line, Tailwind will not work.

It's a tiny change, but I hope it helps some folks.