### PR TITLE
:arrow_up: Update tom dependency

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -28,12 +28,12 @@ glisten = "~> 2.0"
 mist = "~> 1.0"
 simplifile = ">= 2.0.0 and < 3.0.0"
 spinner = "~> 1.1"
-tom = "~> 0.3"
 wisp = "~> 0.14"
 fs = "~> 8.6"
 gleam_httpc = ">= 2.2.0 and < 3.0.0"
 term_size = ">= 1.0.1 and < 2.0.0"
 gleam_crypto = ">= 1.3.0 and < 2.0.0"
+tom = ">= 1.0.1 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -33,7 +33,7 @@ packages = [
   { name = "spinner", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_erlang", "gleam_stdlib", "glearray", "repeatedly"], otp_app = "spinner", source = "hex", outer_checksum = "200BA3D4A04D468898E63C0D316E23F526E02514BC46454091975CB5BAE41E8F" },
   { name = "term_size", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "term_size", source = "hex", outer_checksum = "D00BD2BC8FB3EBB7E6AE076F3F1FF2AC9D5ED1805F004D0896C784D06C6645F1" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
-  { name = "tom", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0831C73E45405A2153091226BF98FB485ED16376988602CC01A5FD086B82D577" },
+  { name = "tom", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "9EECB60150E834A07238BD5C7DF1FF07F7D4C5862BB8A773923D1981C7875FB0" },
   { name = "wisp", version = "0.16.0", build_tools = ["gleam"], requirements = ["exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "A13DAD6A84BED78FF5D7656F3B5125086801BE1AF47427A9A759EA8C484345AB" },
 ]
 
@@ -57,5 +57,5 @@ mist = { version = "~> 1.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }
 spinner = { version = "~> 1.1" }
 term_size = { version = ">= 1.0.1 and < 2.0.0" }
-tom = { version = "~> 0.3" }
+tom = { version = ">= 1.0.1 and < 2.0.0" }
 wisp = { version = "~> 0.14" }


### PR DESCRIPTION
`tom` was fixed on a pre v1 version meaning it would be impossible to use `squirrel` and `dev_tools` in the same project