### PR TITLE
Default to using system's esbuild if it is available

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -37,7 +37,7 @@ packages = [
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
   { name = "term_size", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "term_size", source = "hex", outer_checksum = "D00BD2BC8FB3EBB7E6AE076F3F1FF2AC9D5ED1805F004D0896C784D06C6645F1" },
   { name = "tom", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "228E667239504B57AD05EC3C332C930391592F6C974D0EFECF32FFD0F3629A27" },
-  { name = "wisp", version = "1.4.0", build_tools = ["gleam"], requirements = ["directories", "exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "ADD438907EEDA25384BCD5893BEBE91EE9E32759E156C7DC5B4FE8E758508DC4" },
+  { name = "wisp", version = "1.5.1", build_tools = ["gleam"], requirements = ["directories", "exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "DB7968F777CA77B41AAC8067A5151B022E857E1EECF16BFC9D5F914D0F628844" },
 ]
 
 [requirements]

--- a/src/lustre_dev_tools/cmd.gleam
+++ b/src/lustre_dev_tools/cmd.gleam
@@ -17,3 +17,8 @@ pub fn exec(
 ///
 @external(erlang, "lustre_dev_tools_ffi", "get_cwd")
 pub fn cwd() -> Result(String, Dynamic)
+
+///
+///
+@external(erlang, "lustre_dev_tools_ffi", "find_executable")
+pub fn find_executable(command: String) -> Result(String, Nil)

--- a/src/lustre_dev_tools_ffi.erl
+++ b/src/lustre_dev_tools_ffi.erl
@@ -9,7 +9,8 @@
     get_os/0,
     otp_version/0,
     unzip_esbuild/1,
-    exec/3
+    exec/3,
+    find_executable/1
 ]).
 
 otp_version() ->
@@ -113,6 +114,14 @@ do_exec(Port, Acc) ->
         {Port, {exit_status, Code}} ->
           port_close(Port),
           {error, {Code, list_to_binary(lists:reverse(Acc))}}
+    end.
+
+find_executable(Command) ->
+    Command_ = binary_to_list(Command),
+
+    case os:find_executable(Command_) of
+        false -> {error, nil};
+        CommandPath -> {ok, list_to_binary(CommandPath)}
     end.
 
 fs_start_link(Id, Path) ->


### PR DESCRIPTION
Hi there,

I'm not entirely sure that this is functionality that you would even want, but I'm exploring Gleam and Lustre, and thought I'd experiment.

If you'd prefer to default to the `build/.lustre/bin/esbuild` binary (if it exists) I'd be happy to make the appropriate changes.

Closes #84