### PR TITLE
Fix the condition to detect OpenBSD on amd64, add OpenBSD arm64 and bump esbuild version

### DIFF
--- a/src/lustre_dev_tools/esbuild.gleam
+++ b/src/lustre_dev_tools/esbuild.gleam
@@ -194,10 +194,15 @@ fn get_download_url_and_hash(os, cpu) {
         base <> "netbsd-x64/-/netbsd-x64-0.19.10.tgz",
         "C8F6E2CB79B1DDC2AD42C0AE25FB2A769A989E36B917B231CF9847B683D6DD8D",
       ))
-    "openbsd", "x64" ->
+    "openbsd", "x86_64" ->
       Ok(#(
-        base <> "openbsd-x64/-/openbsd-x64-0.19.10.tgz",
-        "AFEBEAD35BB5A1B921C126E70E0D76CF04DB64FA53C60E0779816CFA9E1F9A11",
+        base <> "openbsd-x64/-/openbsd-x64-0.25.1.tgz",
+        "C3445E0A10F937088B79C1382A2578D1ACCFE9549E3ABB9BB166C47DD430B587",
+      ))
+    "openbsd", "arm64" ->
+      Ok(#(
+        base <> "openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
+        "7E12C970BBC4DBA7C1B6E09E9A10C7B9E51EB63708E52FA3BFB26CCE66A3F6E1",
       ))
     "sunos", "x64" ->
       Ok(#(

--- a/src/lustre_dev_tools/esbuild.gleam
+++ b/src/lustre_dev_tools/esbuild.gleam
@@ -91,123 +91,125 @@ fn get_download_url_and_hash(os, cpu) {
   case os, cpu {
     "android", "arm" ->
       Ok(#(
-        base <> "android-arm/-/android-arm-0.19.10.tgz",
-        "545CF157B0E42E407AC1412F73876119414314D9E31982EBD1E9073336DA5365",
+        base <> "android-arm/-/android-arm-0.25.2.tgz",
+        "B8DBDA0352E2EF679507DE0010C18705CBC7FCD5402ED1BD105B2707FCA4CCA1",
       ))
     "android", "arm64" ->
       Ok(#(
-        base <> "android-arm64/-/android-arm64-0.19.10.tgz",
-        "DFB0A873B1BB9698EF42561B9513FC4A7D8392CE84FBD44FC276883B82AB087E",
+        base <> "android-arm64/-/android-arm64-0.25.2.tgz",
+        "113FD6E8D1381C1EC329E0EAB3D95361211ABAA5231C16CE2BE89B54FA9EC1F2",
       ))
     "android", "x64" ->
       Ok(#(
-        base <> "android-x64/-/android-x64-0.19.10.tgz",
-        "B5D9D170F469BE483F3E16DA6033DFD064ED3DF788C6DC238BA6FE3232BF5653",
+        base <> "android-x64/-/android-x64-0.25.2.tgz",
+        "0966C109B386D137C9092405B199C715C72B5CE8B9A1FA3D8C6B9D4C780FB9D8",
       ))
 
     "darwin", "aarch64" ->
       Ok(#(
-        base <> "darwin-arm64/-/darwin-arm64-0.19.10.tgz",
-        "8CEC451CBD47E228D2D0B740B62870471C22813348398061C06D829BC6610EA9",
-      ))
-    "darwin", "amd64" ->
-      Ok(#(
-        base <> "darwin-arm64/-/darwin-arm64-0.19.10.tgz",
-        "8CEC451CBD47E228D2D0B740B62870471C22813348398061C06D829BC6610EA9",
+        base <> "darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+        "D51E19BA63FE86A6FB6B70596AA0CA32362676274A50CFF6F4EF6E2DE02F4E4A",
       ))
     "darwin", "arm64" ->
       Ok(#(
-        base <> "darwin-arm64/-/darwin-arm64-0.19.10.tgz",
-        "8CEC451CBD47E228D2D0B740B62870471C22813348398061C06D829BC6610EA9",
+        base <> "darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+        "D51E19BA63FE86A6FB6B70596AA0CA32362676274A50CFF6F4EF6E2DE02F4E4A",
+      ))
+    "darwin", "amd64" ->
+      Ok(#(
+        base <> "darwin-x64/-/darwin-x64-0.25.2.tgz",
+        "DE2B564CB345FFAA6CD031A3C40920E8C3658A3321B864F53252F22D810380C5",
       ))
     "darwin", "x86_64" ->
       Ok(#(
-        base <> "darwin-x64/-/darwin-x64-0.19.10.tgz",
-        "4AEC252E72CD56FD31341D960D8DCF0BEBFB858587061FE36B9047FD591C68A3",
+        base <> "darwin-x64/-/darwin-x64-0.25.2.tgz",
+        "DE2B564CB345FFAA6CD031A3C40920E8C3658A3321B864F53252F22D810380C5",
       ))
 
     "freebsd", "aarch64" ->
       Ok(#(
-        base <> "freebsd-arm64/-/freebsd-arm64-0.19.10.tgz",
-        "739E9F6DD3121DB0CD03B70B14C4D17A1854970272B0F988BD035AA876BE254B",
+        base <> "freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+        "A8B16E6529F098CF7F8855CD2C5FBB21D740534181012AB819A4A569D9EACCDF",
       ))
     "freebsd", "amd64" ->
       Ok(#(
-        base <> "freebsd-x64/-/freebsd-x64-0.19.10.tgz",
-        "3E937C849B21B89244A8A62B473E36EEFE793F5BDF602BEDBB314DD33DDBE7EE",
+        base <> "freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+        "B2394FBF3B85390D5D3246C50192D2B1208D83DBF96796CDC67079C66FC0AA48",
       ))
 
-    "linux", "aarch64" ->
-      Ok(#(
-        base <> "linux-arm64/-/linux-arm64-0.19.10.tgz",
-        "D3523B8F7B2540BA5A15C4EE4C747B31DFDC496C7A8A3F3FB0ECCB3008647DB7",
-      ))
     "linux", "arm" ->
       Ok(#(
-        base <> "linux-arm/-/linux-arm-0.19.10.tgz",
-        "99EEB37F5C1AB8750D9CAB6AB04469EF5CA32847B25E1461215276920AFB01B2",
+        base <> "linux-arm/-/linux-arm-0.25.2.tgz",
+        "9BF3844336FD30A1FCCBB6C0617572518A25E0716F98AC9E293B1D28AF97932D",
+      ))
+    "linux", "aarch64" ->
+      Ok(#(
+        base <> "linux-arm64/-/linux-arm64-0.25.2.tgz",
+        "87D512B94D322CC3F008DC4EC5D9D47E82001DBEE692B825F332B157AFDF0282",
       ))
     "linux", "arm64" ->
       Ok(#(
-        base <> "linux-arm64/-/linux-arm64-0.19.10.tgz",
-        "D3523B8F7B2540BA5A15C4EE4C747B31DFDC496C7A8A3F3FB0ECCB3008647DB7",
+        base <> "linux-arm64/-/linux-arm64-0.25.2.tgz",
+        "87D512B94D322CC3F008DC4EC5D9D47E82001DBEE692B825F332B157AFDF0282",
       ))
     "linux", "ia32" ->
       Ok(#(
-        base <> "linux-ia32/-/linux-ia32-0.19.10.tgz",
-        "3D69F7B90C62E6D94140355A92EDB15B8BFB934096C6E518BE41DAD6249BF38E",
+        base <> "linux-ia32/-/linux-ia32-0.25.2.tgz",
+        "79BFB8B6B95F32C4EE8BBB21078A9E0F8DED3E148F69EAA690BCC0ABDB8D15F1",
       ))
     "linux", "x64" ->
       Ok(#(
-        base <> "linux-x64/-/linux-x64-0.19.10.tgz",
-        "73CA82A3C9049315027E60A50AF53C2ABFDE678BF66562B407FACA7FD3FAD6F4",
+        base <> "linux-x64/-/linux-x64-0.25.2.tgz",
+        "52136A4B1F12F8B2567E0550B802F920593B012B22FEC64F46C99DF938466BBA",
       ))
     "linux", "x86_64" ->
       Ok(#(
-        base <> "linux-x64/-/linux-x64-0.19.10.tgz",
-        "73CA82A3C9049315027E60A50AF53C2ABFDE678BF66562B407FACA7FD3FAD6F4",
-      ))
-
-    "win32", "arm64" ->
-      Ok(#(
-        base <> "win32-arm64/-/win32-arm64-0.19.10.tgz",
-        "2D0EC6ED7C5BA6F2D99CBB1428C1FAABFA7D42E7435BC40474C5787DCD1FF37C",
-      ))
-    "win32", "ia32" ->
-      Ok(#(
-        base <> "win32-ia32/-/win32-ia32-0.19.10.tgz",
-        "5BFBF08A8EDC16D53FE2103C68705DC3B4ABDFA6C44919B9602495ABA523BA46",
-      ))
-    "win32", "x64" ->
-      Ok(#(
-        base <> "win32-x64/-/win32-x64-0.19.10.tgz",
-        "03EFF9A74ED7C72C8E4ACE85F6BFD2D097169D8D6E7D691AE1D7959F2912B785",
-      ))
-    "win32", "x86_64" ->
-      Ok(#(
-        base <> "win32-x64/-/win32-x64-0.19.10.tgz",
-        "03EFF9A74ED7C72C8E4ACE85F6BFD2D097169D8D6E7D691AE1D7959F2912B785",
+        base <> "linux-x64/-/linux-x64-0.25.2.tgz",
+        "52136A4B1F12F8B2567E0550B802F920593B012B22FEC64F46C99DF938466BBA",
       ))
 
     "netbsd", "x64" ->
       Ok(#(
-        base <> "netbsd-x64/-/netbsd-x64-0.19.10.tgz",
-        "C8F6E2CB79B1DDC2AD42C0AE25FB2A769A989E36B917B231CF9847B683D6DD8D",
+        base <> "netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+        "0F1DC50A1A688DF5D3E41EDD9DB5B425D9B23566770029ACA4FB6C79D6F1806F",
+      ))
+
+    "openbsd", "arm64" ->
+      Ok(#(
+        base <> "openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+        "EB8B7F6BB6E56E869DA19573D5088991CA59C12870FC6180F249BA5D34163635",
       ))
     "openbsd", "x86_64" ->
       Ok(#(
-        base <> "openbsd-x64/-/openbsd-x64-0.25.1.tgz",
-        "C3445E0A10F937088B79C1382A2578D1ACCFE9549E3ABB9BB166C47DD430B587",
+        base <> "openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+        "196B5E6C9E4EC7895051E49CAF59F5720B9861FE87E66776961C296AE5217A18",
       ))
-    "openbsd", "arm64" ->
-      Ok(#(
-        base <> "openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
-        "7E12C970BBC4DBA7C1B6E09E9A10C7B9E51EB63708E52FA3BFB26CCE66A3F6E1",
-      ))
+
     "sunos", "x64" ->
       Ok(#(
-        base <> "sunos-x64/-/sunos-x64-0.19.10.tgz",
-        "B1E9F969433574BD43A293FA3A3C71C88B8C4CF841957DAAA2CF83A90ADAAB7E",
+        base <> "sunos-x64/-/sunos-x64-0.25.2.tgz",
+        "409B456C7C341D9EF97621DA4AF84AD1CF0641B0546FE0D5D28A871C78BA2949",
+      ))
+
+    "win32", "arm64" ->
+      Ok(#(
+        base <> "win32-arm64/-/win32-arm64-0.25.2.tgz",
+        "CAB0263FFB5CFC6B0609781EA0BF9565F0845C83802B86AB39E2107410911157",
+      ))
+    "win32", "ia32" ->
+      Ok(#(
+        base <> "win32-ia32/-/win32-ia32-0.25.2.tgz",
+        "F62A2BE084752412CD3B6603668374A844DD3F8C8C37B3EB7382CE3C0F1F1C93",
+      ))
+    "win32", "x64" ->
+      Ok(#(
+        base <> "win32-x64/-/win32-x64-0.25.2.tgz",
+        "C4D5FD874A44782032FC3BF5FE77D9CCE5D8C5B1DE51D9AE8EE68B40C2FC1ED2",
+      ))
+    "win32", "x86_64" ->
+      Ok(#(
+        base <> "win32-x64/-/win32-x64-0.25.2.tgz",
+        "C4D5FD874A44782032FC3BF5FE77D9CCE5D8C5B1DE51D9AE8EE68B40C2FC1ED2",
       ))
 
     _, _ -> Error(UnknownPlatform("esbuild", os, cpu))


### PR DESCRIPTION
I noticed that on OpenBSD/amd64, lustre_dev_tools failed to download an appropriate version of esbuild because the CPU identifier was misspelt. While there, I also included the version for OpenBSD/arm64.

Due to issues that older esbuild versions had with OpenBSD (see https://github.com/evanw/esbuild/issues/3523), I also bumped the version to the latest release.