### PR TITLE
Bump fs to 11.4.1 and adjust check_live_reloading/0 to match

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -16,7 +16,7 @@ internal_modules = ["lustre_dev_tools", "lustre_dev_tools/*"]
 [dependencies]
 argv = "~> 1.0"
 filepath = "~> 1.0"
-fs = "~> 8.6"
+fs = "~> 11.4.1"
 gleam_community_ansi = "~> 1.4"
 gleam_crypto = ">= 1.3.0 and < 2.0.0"
 gleam_deque = ">= 1.0.0 and < 2.0.0"

--- a/src/lustre_dev_tools_ffi.erl
+++ b/src/lustre_dev_tools_ffi.erl
@@ -137,6 +137,8 @@ check_live_reloading() ->
         case os:type() of
             {unix, darwin} -> fsevents;
             {unix, linux} -> inotifywait;
+            {unix, freebsd} -> inotifywait;
+            {unix, openbsd} -> inotifywait;
             {unix, sunos} -> undefined;
             {unix, _} -> kqueue;
             {win32, nt} -> inotifywait_win32;


### PR DESCRIPTION
I would like to propose a bump of ``fs`` to ``11.4.1``. With that release, ``fs`` uses ``inotifywait`` on FreeBSD and OpenBSD. With that and a small adjustment to ``check_live_reloading/0`` dev-tools will work out of the box on those two BSDs.

See also https://github.com/synrc/fs/pull/75