### PR TITLE
Fix bug with import statements using single quotes

### DIFF
--- a/src/lustre_dev_tools/cli/add.gleam
+++ b/src/lustre_dev_tools/cli/add.gleam
@@ -1,5 +1,6 @@
 // IMPORTS ---------------------------------------------------------------------
 
+import lustre_dev_tools/project
 import gleam/io
 import glint.{type Command}
 import lustre_dev_tools/cli.{do}
@@ -53,14 +54,9 @@ in your project but will not download it automatically.
     "
   use <- glint.command_help(description)
   use <- glint.unnamed_args(glint.EqArgs(0))
-  use os <- glint.flag(flag.tailwind_os())
-  use cpu <- glint.flag(flag.tailwind_cpu())
   use _, _, flags <- glint.command()
   let script = {
-    use os <- do(cli.get_string("os", get_os(), ["add"], os))
-    use cpu <- do(cli.get_string("cpu", get_cpu(), ["add"], cpu))
-
-    tailwind.setup(os, cpu)
+    tailwind.get_entry_file_and_then(project.root(), tailwind.init_tailwind_css)
   }
 
   case cli.run(script, flags) {


### PR DESCRIPTION
The code to check if it contains modern tailwind variant is a bit brittle. My prettier overwrites the double quotes in CSS files with single quotes, and after that it won't detect it no more. Then no bundle is generated, I have now made it a litte bit less strict so it can contain both " and ', and also will not break if an extra space is added or not.

I have changed a bit of code so that the add function only creates the import and the bundler will do the installation. The code is a bit convoluted if I may say so, so maybe something else broke again, or not work as expected. The old code also read the css file twice, which is not very efficient.

In the components code I didn't find anything related to the flag `detect_tailwind` so maybe that is an existing bug (or works as expected). 

Wouldn't a better name for that flag maybe be bundle_tailwind? Because that is what you either want or not want to do.

Fixes #113