### PR TITLE
with-sha-fix: Fixed a couple of mismatching SHAs

### DIFF
--- a/src/lustre_dev_tools/bin/bun.gleam
+++ b/src/lustre_dev_tools/bin/bun.gleam
@@ -343,11 +343,11 @@ const hashes = [
   ),
   #(
     "bun-linux-aarch64-musl",
-    "e85feb78bbff552ff6dcde0d99a7618f20df4544efd6248d9e97939709bc9406",
+    "88c54cd66169aeb5ff31bc0c9d74a8017c7e6965597472ff49ecc355acb3a884",
   ),
   #(
     "bun-linux-aarch64",
-    "88c54cd66169aeb5ff31bc0c9d74a8017c7e6965597472ff49ecc355acb3a884",
+    "a97c687fb5e54de4e2fb0869a7ac9a2d9c3af75ac182e2b68138c1dd8f98131b",
   ),
   #(
     "bun-linux-x64-baseline",


### PR DESCRIPTION
Deploying to Fly.io via the recommended `Dockerfile` copypaste from https://hexdocs.pm/lustre/guide/07-full-stack-deployments.html was blowing out:

```
6.504   Compiling shared
6.540    Compiled in 6.35s
6.571     Running lustre/dev.main
7.478    Downloading Bun v1.2.22...
9.106    Verifying download hash...
9.166
9.166 I ran into a problem while trying to verify the integrity of the Bun archive I
9.166 just downloaded. The expected hash was:
9.166
9.166   e85feb78bbff552ff6dcde0d99a7618f20df4544efd6248d9e97939709bc9406
9.166
9.166 But the actual hash was:
9.166
9.166   88c54cd66169aeb5ff31bc0c9d74a8017c7e6965597472ff49ecc355acb3a884
9.166
9.166 This can happen if you have a proxy or firewall that interferes with the download.
9.166 If you think this is a bug, please open an issue at:
9.166
9.166 https://github.com/lustre-labs/dev-tools/issues/new
```

I verified these two SHAs against https://github.com/oven-sh/bun/releases/download/bun-v1.22.2/SHASUM256.txt, and also downloaded them and checked them for myself with `sha256sum`.

The entry for `bun-linux-aarch64-musl` was actually the hash for `bun-linux-aarch64`, and the hash for `bun-linux-aarch64` didn't match any value in the list.