### PR TITLE
Fix incorrect path for static assets

### DIFF
--- a/src/lustre/dev.gleam
+++ b/src/lustre/dev.gleam
@@ -373,14 +373,8 @@ key `tools.lustre.build.outdir`.
   use _ <- result.try(case simplifile.is_directory(project.assets) {
     Ok(True) -> {
       use _ <- result.try(
-        simplifile.copy_directory(
-          project.assets,
-          filepath.join(options.outdir, "assets"),
-        )
-        |> result.map_error(error.CouldNotWriteFile(
-          filepath.join(options.outdir, "assets"),
-          _,
-        )),
+        simplifile.copy_directory(project.assets, options.outdir)
+        |> result.map_error(error.CouldNotWriteFile(options.outdir, _)),
       )
 
       cli.success("Assets copied.", False)


### PR DESCRIPTION
Comming from discord message:

> with new dev tool update, I think there is a new problem 😅 
> 
> In docs, the build have all the assets without with no assets folder itself:
> ```dist/
> ├── index.html
> ├── app.js
> └── image/
>     └── wibble.png
> ```
> 
> But when im trying to build the app, all the assets are still inside the assets folder, so when im deploying the app, all the content are not being fetched properly, since the paths to assets are incorrect:
> ```ls -a dist
> .  ..  app.css  app.js  assets  index.html
> ```