### PR TITLE
:bug: fix: #136 `find_exec` to returns absolute path to executable tools

### DIFF
--- a/src/lustre_dev_tools/system.gleam
+++ b/src/lustre_dev_tools/system.gleam
@@ -1,3 +1,6 @@
+import filepath
+import gleam/result
+
 ///
 ///
 @external(erlang, "system_ffi", "detect_os")
@@ -18,6 +21,12 @@ pub fn is_alpine() -> Bool
 ///
 @external(erlang, "system_ffi", "run")
 pub fn run(command: String) -> Result(String, String)
+
+/// Find executable from path param into file system and returns absolute path.
+/// see erlang: `os:find_executable/1`.
+/// 
+@external(erlang, "system_ffi", "find_exec")
+pub fn find_exec(executable: String) -> Result(String, String)
 
 @external(erlang, "system_ffi", "find")
 pub fn find(executable: String) -> Result(String, Nil)

--- a/src/lustre_dev_tools/system_ffi.erl
+++ b/src/lustre_dev_tools/system_ffi.erl
@@ -1,6 +1,6 @@
 -module(system_ffi).
 
--export([detect_os/0, detect_arch/0, is_alpine/0, run/1, find/1, exit/1]).
+-export([detect_os/0, detect_arch/0, is_alpine/0, run/1, find_exec/1, find/1, exit/1]).
 
 detect_os() ->
     case os:type() of
@@ -32,6 +32,15 @@ detect_arch() ->
 
 is_alpine() ->
     filelib:is_file("/etc/alpine-release").
+
+find_exec(ExeName) ->
+    ExeName1 = unicode:characters_to_list(ExeName),
+    case os:find_executable(ExeName1) of
+        false ->
+            {error, <<"Not found">>};
+        FullPath ->
+            {ok, unicode:characters_to_binary(FullPath)}
+    end.
 
 run(Cmd) ->
     case catch os:cmd(


### PR DESCRIPTION
- #136 

Adding new function into system_ffi and system.gleam to returns absolute path to executable if exists, else returns Error(String).

We needs this funciton to verify if executable is in lustre bin and return absolute path to exec fix windows not work with relative path to exe