### PR TITLE
Load the app.dev.js file on the root instead on the relative path

### DIFF
--- a/src/lustre_dev_tools/build/html.gleam
+++ b/src/lustre_dev_tools/build/html.gleam
@@ -112,7 +112,10 @@ pub fn dev(
         case project.has_node_modules {
           True ->
             html.script(
-              [attribute.type_("module"), attribute.src(entry <> ".dev.js")],
+              [
+                attribute.type_("module"),
+                attribute.src("/" <> entry <> ".dev.js"),
+              ],
               "",
             )
 


### PR DESCRIPTION
The HTML that was being build had the wrong path to the `#{app}.dev.js` file resulting in the app to not load when on a deeper path, such as `/topics/1`. Looks like this only occurs when the project has a `node_modules` directory