### PR TITLE
Trim directory from start of changed file path with polly_watcher

### DIFF
--- a/src/lustre_dev_tools/dev/watcher.gleam
+++ b/src/lustre_dev_tools/dev/watcher.gleam
@@ -137,6 +137,7 @@ fn start_polly_watcher(
   case change {
     polly.Changed(path:) | polly.Created(path:) | polly.Deleted(path:) -> {
       let assert Ok(dir) = list.find(watch, string.starts_with(path, _))
+      let path = string.drop_start(path, string.length(dir) + 1)
 
       case Some(path) == option.map(tailwind_entry, string.append(_, ".css")) {
         True -> Nil


### PR DESCRIPTION
Polly's file changed update includes the directory in the file path. This needs to be removed to make the behaviour consistent with Bun's fs.watch notification and ensure that the changed file is reloaded correctly.

Without this, the console notification in the browser is
```
[lustre] Asset updated ./assets/css/styles.css
```
when instead it should be
```
[lustre] Asset updated css/styles.css
```

I've verified that polling-based live reload works even with atomic writes enabled after this change was made. It's great to have this option, by the way. Thank you for adding it!