### PR TITLE
fix: check that output css file has changes on tailwind watch output

### DIFF
--- a/src/lustre_dev_tools/bin/tailwind.gleam
+++ b/src/lustre_dev_tools/bin/tailwind.gleam
@@ -268,8 +268,7 @@ pub fn watch(
       // nothing else so there's no data we'd need to parse out anyway.
       on_unknown: fn() {
         // Check that the output file has actually been modified before resending assets 
-        let file_info =
-          simplifile.file_info(filepath.join(project.src, output <> ".css"))
+        let file_info = simplifile.file_info(output <> ".css")
         case file_info {
           Ok(info) -> {
             case info.mtime_seconds > info.atime_seconds {


### PR DESCRIPTION
This fixes behavior where assets with tailwind are being sent to the client on keypress and instead only triggers a refresh of the css file when the output css file has changed.