### PR TITLE
:bug: remove ^ from tailwind regex

### DIFF
--- a/src/lustre_dev_tools/bin/tailwind.gleam
+++ b/src/lustre_dev_tools/bin/tailwind.gleam
@@ -208,7 +208,7 @@ pub fn detect(project: Project, entry: String) -> Result(Detection, Error) {
         |> result.map_error(error.CouldNotReadFile(path, _)),
       )
 
-      let assert Ok(re) = regexp.from_string("^@import\\s+['\"]tailwindcss")
+      let assert Ok(re) = regexp.from_string("@import\\s+['\"]tailwindcss")
       case regexp.check(re, css) {
         True -> Ok(HasTailwindEntry(path:))
         False -> Ok(HasViableEntry(path:))


### PR DESCRIPTION
Howdy howdy

Found an issue around Tailwind while trying to import a webfont, where the font won't load unless it's the first directive, but Lustre won't pick up Tailwind if the file doesn't begin with @import "tailwind". Feels an easy fix to just remove the `^` from the regular expression that checks for Tailwind.