### PR TITLE
:bug: Accept standard-table form for proxy config

### DIFF
--- a/src/lustre_dev_tools/dev/proxy.gleam
+++ b/src/lustre_dev_tools/dev/proxy.gleam
@@ -62,7 +62,7 @@ pub fn get_proxies_from_config(
   case tom.get(config, path) {
     Ok(proxy_toml) -> {
       case proxy_toml {
-        tom.InlineTable(table) ->
+        tom.InlineTable(table) | tom.Table(table) ->
           table
           |> parse_proxy
           |> result.map(list.wrap)
@@ -70,7 +70,8 @@ pub fn get_proxies_from_config(
           array
           |> list.map(fn(table) {
             case table {
-              tom.InlineTable(proxy) -> parse_proxy(proxy)
+              tom.InlineTable(proxy) | tom.Table(proxy) ->
+                parse_proxy(proxy)
               _ -> Error(error.ProxyInvalidConfig)
             }
           })


### PR DESCRIPTION
Previously, only the inline-table form was recognized, e.g.

```toml
[tools.lustre.dev]
proxy = { from = "/api", to = "http://localhost:3000/api" }
```

The equivalent standard-table form failed with `ProxyInvalidConfig`:

```toml
[tools.lustre.dev.proxy]
from = "/api"
to = "http://localhost:3000/api"
```

Accept both `tom.InlineTable` and `tom.Table` in `get_proxies_from_config`, for the single-proxy case and entries inside an array of proxies.