### PR TITLE
proposed fix for #147

### DIFF
--- a/pages/toml-reference.md
+++ b/pages/toml-reference.md
@@ -208,3 +208,7 @@ application or serves during development.
   be included in the `<title>` tag in the `<head>` of the document.
 
   Default: the name of the Gleam project as specified in `gleam.toml`.
+
+- **`url_prefix = string`**: prefix for the `src` attributed used by the generated `script` tag. This path prefix is relative to the generated `index.html` file.
+  
+  Default: `"./"`

--- a/src/lustre_dev_tools/build/html.gleam
+++ b/src/lustre_dev_tools/build/html.gleam
@@ -50,10 +50,8 @@ pub fn generate(
 
         scripts(project),
 
-        html.script(
-          [attribute.type_("module"), attribute.src("/" <> name <> ".js")],
-          "",
-        ),
+        script(project, name),
+
       ]),
 
       body(project),
@@ -259,6 +257,16 @@ fn scripts(project: Project) -> Element(msg) {
     )
     |> result.unwrap([])
   })
+}
+
+fn script(project: Project, name: String) -> Element(msg) {
+  let url_prefix = tom.get_string(project.options, ["html", "url_prefix"])
+  |> result.unwrap("./")
+
+  html.script(
+    [attribute.type_("module"), attribute.src(url_prefix <> name <> ".js")],
+    "",
+  )
 }
 
 fn as_attribute(key: String, toml: Toml) -> Result(Attribute(msg), Nil) {

--- a/src/lustre_dev_tools/build/html.gleam
+++ b/src/lustre_dev_tools/build/html.gleam
@@ -261,7 +261,7 @@ fn scripts(project: Project) -> Element(msg) {
 
 fn script(project: Project, name: String) -> Element(msg) {
   let url_prefix = tom.get_string(project.options, ["html", "url_prefix"])
-  |> result.unwrap("./")
+  |> result.unwrap("")
 
   html.script(
     [attribute.type_("module"), attribute.src(url_prefix <> name <> ".js")],


### PR DESCRIPTION
This change does 2 things:

1. adds a `url_prefix` option in the toml file so you can specify a prefix for the generated `.js` file to be used `index.html`
2. makes the default prefix `""` instead of `"/"` so that your webserver can be in a different directory. This addresses issue #147  