### PR TITLE
Fix toml path in help message being incorrect

### DIFF
--- a/src/lustre_dev_tools/error.gleam
+++ b/src/lustre_dev_tools/error.gleam
@@ -68,7 +68,7 @@ Make sure you're connected to the internet and that no firewall or proxy is
 blocking connections to GitHub.
 
 Hint: you can provide a path to a local Tailwind binary by setting the
-`tools.lustre.bin.tailwind` field in your `gleam.toml`. Use the string `\"system\"`
+`tools.lustre.bin.tailwindcss` field in your `gleam.toml`. Use the string `\"system\"`
 to use the Tailwind binary accessible in your system path.
         "
       |> string.replace("${reason}", string.inspect(reason))
@@ -239,7 +239,7 @@ If you think this is a bug, please open an issue at:
 https://github.com/lustre-labs/dev-tools/issues/new
 
 Hint: you can provide a path to a local Tailwind binary by setting the
-`tools.lustre.bin.tailwind` field in your `gleam.toml`. Use the string `\"system\"`
+`tools.lustre.bin.tailwindcss` field in your `gleam.toml`. Use the string `\"system\"`
 to use the Tailwind binary accessible in your system path.
         "
       |> string.replace("${expected}", expected)


### PR DESCRIPTION
-Little context
Hi! Was messing around in a fresh project, and normally I like to run tailwind by hand but kept it on instead because why not, though, because I'm on nixos I cannot just download and run any binary (impurity yadda yadda), so I would set it to "system" so the flake would pick it up... And then I saw... this! Seems me and the devtools made the same mistake, but looking up the docs I realised... it's `tailwindcss` :)

sooo I decided to PR it